### PR TITLE
Install without updating setting file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,25 +15,8 @@ You should have installed the Windows Terminal on your system. If you havent ins
 
 Download and Extract files and Follow This Steps After Downloading, and will configure everything for you.
 
-## Step 1
-Open Windows Terminal and Open settings. use Command `Ctrl + ,` or by clicking the drop down menu.  
+## Install
 
-<img src="https://github.com/MisterJ936/Explorer-Context-Menu-Integration-for-windows-terminal/blob/master/images/open%20setting.png?raw=true" />
-
-and then under profile -> default: add `startingDirectory`
-
-```
-"profiles": {
-     "defaults" : {
-          ...
-          "startingDirectory": "." //add this
-     }
-}
-```
-
-<img src="https://github.com/MisterJ936/Explorer-Context-Menu-Integration-for-windows-terminal/blob/master/images/add%20startingdirectory.png?raw=true" />
-
-## Step 2
 Run the `Install.bat` to automatically configure the context menu for you. 
 
 

--- a/src/bat/Install.bat
+++ b/src/bat/Install.bat
@@ -1,9 +1,9 @@
 reg add "HKCU\Software\Classes\Directory\shell\Open Windows Terminal here" /v icon /d %LOCALAPPDATA%\terminal\wt_32.ico /f
-reg add "HKCU\Software\Classes\Directory\shell\Open Windows Terminal here\command" /d "\"%LOCALAPPDATA%\Microsoft\WindowsApps\wt.exe\"" /f
+reg add "HKCU\Software\Classes\Directory\shell\Open Windows Terminal here\command" /d "\"%LOCALAPPDATA%\Microsoft\WindowsApps\wt.exe\" \"-d .\"" /f
 reg add "HKCU\Software\Classes\Directory\Background\shell\Open Windows Terminal here" /v icon /d %LOCALAPPDATA%\terminal\wt_32.ico /f
-reg add "HKCU\Software\Classes\Directory\Background\shell\Open Windows Terminal here\command" /d "\"%LOCALAPPDATA%\Microsoft\WindowsApps\wt.exe\"" /f
+reg add "HKCU\Software\Classes\Directory\Background\shell\Open Windows Terminal here\command" /d "\"%LOCALAPPDATA%\Microsoft\WindowsApps\wt.exe\" \"-d .\"" /f
 reg add "HKCU\Software\Classes\LibraryFolder\Background\shell\Open Windows Terminal here" /v icon /d %LOCALAPPDATA%\terminal\wt_32.ico /f
-reg add "HKCU\Software\Classes\LibraryFolder\Background\shell\Open Windows Terminal here\command" /d "\"%LOCALAPPDATA%\Microsoft\WindowsApps\wt.exe\"" /f
+reg add "HKCU\Software\Classes\LibraryFolder\Background\shell\Open Windows Terminal here\command" /d "\"%LOCALAPPDATA%\Microsoft\WindowsApps\wt.exe\" \"-d .\"" /f
 robocopy .\terminal %LOCALAPPDATA%\terminal /E /IS /IT
 echo "Context Menu For Windows Terminal is Configured Successfully! Try Righ Clicking to see the option."
 pause


### PR DESCRIPTION
Hi,

I got an issue when use your installation that it overwrites my own "startingDirectory" when I start the terminal normal way.
From this document:
https://docs.microsoft.com/en-us/windows/terminal/command-line-arguments?tabs=windows#target-a-directory
we could using the -d argument to start wt in current directory, so I updated the bat file little bit.
With this update we don't need to update setting file and it does not overwrite the startingDirectory when start wt normal way.

Best regards,
Kha Vo